### PR TITLE
meson.build: fix race-condition when building tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ tests = executable(
     'test/astc/bitmanip.cc',
     'test/astc/matrix.cc',
     'test/astc/pca.cc',
+    tables_integer_sequence_encoding,
     link_with: [astc]
 )
 


### PR DESCRIPTION
test/astc/bise.cc depends on tables_integer_sequence_encoding.h
generated in astc, without explicitly depending on it:
```
./test/astc/bise.cc:#include "astc/integer_sequence_encoding.h"
  ./astc/integer_sequence_encoding.h:#include "astc/tables_integer_sequence_encoding.h"
```
which sometimes can cause build failure like:
```
[1/19] c++ -Iastcrt-tests.p -I. -I../astcrt -Iastc -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++1z -O0 -g -MD -MQ astcrt-tests.p/test_main.cc.o -MF astcrt-tests.p/test_main.cc.o.d -o as
tcrt-tests.p/test_main.cc.o -c ../astcrt/test/main.cc
In file included from ../git/test/astc/bise.cc:5:
../git/astc/integer_sequence_encoding.h:9:10: fatal error: astc/tables_integer_sequence_encoding.h: No such file or directory
    9 | #include "astc/tables_integer_sequence_encoding.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
...
[8/19] /usr/bin/env python astcrt/pybits/codegen.py datasize astc/tables_data_size.h
[9/19] /usr/bin/env python astcrt/pybits/codegen.py bise astc/tables_integer_sequence_encoding.h
[10/19] /usr/bin/env python astcrt/pybits/codegen.py quantize astc/tables_color_quantization.h
```

To reliably reproduce this race-condition add short sleep in
pybits/codegen.py, then it fails every single time without
this patch.

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>